### PR TITLE
Fix Fail to access: Can't assign requested address (os error 49)

### DIFF
--- a/src/prosafe_switch.rs
+++ b/src/prosafe_switch.rs
@@ -282,18 +282,18 @@ impl ProSafeSwitch {
         let req = QueryRequest::new(cmd, &iface.hardware_addr()?, &HardwareAddr::zero());
         let req = req.encode()?;
 
-        let ssocket = UdpSocket::bind(SocketAddr::new(iface_addr, 63321))?;
-        let _ = ssocket.set_read_timeout(Some(self.timeout));
+        let socket = UdpSocket::bind("0.0.0.0:63321")?;
+        let _ = socket.set_read_timeout(Some(self.timeout));
 
         let sw_addr = format!("{}:{}", self.hostname, 63322)
             .to_socket_addrs()
             .unwrap()
             .next()
             .unwrap();
-        ssocket.send_to(&req, sw_addr)?;
+        socket.send_to(&req, sw_addr)?;
 
         let mut buf = [0; 1024];
-        let (_len, _src_addr) = ssocket.recv_from(&mut buf)?;
+        let (_len, _src_addr) = socket.recv_from(&mut buf)?;
 
         Ok(Vec::from(&buf as &[u8]))
     }

--- a/src/prosafe_switch.rs
+++ b/src/prosafe_switch.rs
@@ -283,8 +283,7 @@ impl ProSafeSwitch {
         let req = req.encode()?;
 
         let ssocket = UdpSocket::bind(SocketAddr::new(iface_addr, 63321))?;
-        let rsocket = UdpSocket::bind("255.255.255.255:63321")?;
-        let _ = rsocket.set_read_timeout(Some(self.timeout));
+        let _ = ssocket.set_read_timeout(Some(self.timeout));
 
         let sw_addr = format!("{}:{}", self.hostname, 63322)
             .to_socket_addrs()
@@ -294,7 +293,7 @@ impl ProSafeSwitch {
         ssocket.send_to(&req, sw_addr)?;
 
         let mut buf = [0; 1024];
-        let (_len, _src_addr) = rsocket.recv_from(&mut buf)?;
+        let (_len, _src_addr) = ssocket.recv_from(&mut buf)?;
 
         Ok(Vec::from(&buf as &[u8]))
     }


### PR DESCRIPTION
I built and executed prosafe_exporter on macOS and Raspbian, 
but was not able to bind a udp socket on the broadcast address 255.255.255.255 even as root.
I always received the error message "Can't assign requested address (os error 49)".
My prosafe switch (GS108Ev3) targets the querying node anyway, 
so I changed the code to reuse the already open "ssocket" on "iface_addr".
This works fine on both platforms.
